### PR TITLE
modernize: csproj, XML docs, README, CI/CD, SonarCloud (v3.2.0)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,4 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+*.yml text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to NuGet
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    name: Pack & push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore & build
+        run: |
+          dotnet restore
+          dotnet build --configuration Release --no-restore
+
+      - name: Pack
+        run: dotnet pack StandardInterfaces/StandardInterfaces.csproj --configuration Release --no-build -p:PackageVersion=${{ github.ref_name }}
+
+      - name: Login to NuGet (Trusted Publishing)
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER }}
+
+      - name: Push
+        run: dotnet nuget push StandardInterfaces/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
     name: Pack & push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5
         with:
           dotnet-version: 8.0.x
 
@@ -29,7 +29,7 @@ jobs:
         run: dotnet pack StandardInterfaces/StandardInterfaces.csproj --configuration Release --no-build -p:PackageVersion=${{ github.ref_name }}
 
       - name: Login to NuGet (Trusted Publishing)
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1
         with:
           user: ${{ vars.NUGET_USER }}
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build & analyze
         env:
-          SONAR_TOKEN: $SONAR_TOKEN
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           dotnet-sonarscanner begin \
             /k:"PFalkowski_StandardInterfaces" /o:"pfalkowski" \

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build & analyze
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: $SONAR_TOKEN
         run: |
           dotnet-sonarscanner begin \
             /k:"PFalkowski_StandardInterfaces" /o:"pfalkowski" \

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,51 @@
+# SonarCloud static analysis (no coverage — pure interface library with no test project).
+# Requires: SONAR_TOKEN repo secret, Automatic Analysis OFF in SonarCloud project settings.
+name: SonarCloud
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  sonar:
+    name: Analyze
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Install scanner
+        run: dotnet tool install --global dotnet-sonarscanner
+
+      - name: Build & analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet-sonarscanner begin \
+            /k:"PFalkowski_StandardInterfaces" /o:"pfalkowski" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.token="$SONAR_TOKEN"
+          dotnet build --configuration Release
+          dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -14,23 +14,23 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           distribution: temurin
           java-version: 17
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5
         with:
           dotnet-version: 8.0.x
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/README.md
+++ b/README.md
@@ -1,4 +1,108 @@
 # StandardInterfaces
 
-[![NuGet version (StandardInterfaces)](https://img.shields.io/nuget/v/StandardInterfaces.svg)](https://www.nuget.org/packages/StandardInterfaces/)
-[![Licence (StandardInterfaces)](https://img.shields.io/github/license/mashape/apistatus.svg)](https://choosealicense.com/licenses/mit/)
+[![CI](https://github.com/PFalkowski/StandardInterfaces/actions/workflows/ci.yml/badge.svg)](https://github.com/PFalkowski/StandardInterfaces/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=PFalkowski_StandardInterfaces&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=PFalkowski_StandardInterfaces)
+[![NuGet](https://img.shields.io/nuget/v/StandardInterfaces.svg)](https://www.nuget.org/packages/StandardInterfaces)
+[![Downloads](https://img.shields.io/nuget/dt/StandardInterfaces.svg)](https://www.nuget.org/packages/StandardInterfaces)
+[![License: MIT](https://img.shields.io/github/license/PFalkowski/StandardInterfaces.svg)](https://github.com/PFalkowski/StandardInterfaces/blob/master/LICENSE)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/piotrfalkowski)
+
+Everyday .NET design-pattern interfaces in a single `netstandard2.0` package — no dependencies, no opinions beyond the contracts.
+
+## Install
+
+```bash
+dotnet add package StandardInterfaces
+```
+
+## Interfaces
+
+### Repository pattern
+
+```csharp
+public interface IReadOnlyRepository<TEntity> where TEntity : class
+{
+    int Count();
+    int Count(Expression<Func<TEntity, bool>> predicate);
+    TEntity Get(Expression<Func<TEntity, bool>> predicate);
+    IEnumerable<TEntity> GetAll();
+    IEnumerable<TEntity> GetAll(Expression<Func<TEntity, bool>> predicate);
+}
+
+public interface IRepository<TEntity> : IReadOnlyRepository<TEntity> where TEntity : class
+{
+    void Add(TEntity entity);
+    void AddOrUpdate(TEntity entity);
+    void AddRange(IEnumerable<TEntity> entities);
+    void Remove(TEntity entity);
+    void RemoveRange(IEnumerable<TEntity> entities);
+    void RemoveAll(Expression<Func<TEntity, bool>> predicate);
+    void RemoveAll();
+    int SaveChanges();
+}
+```
+
+### Unit of work
+
+```csharp
+public interface IUnitOfWork : IDisposable
+{
+    void Complete();
+}
+```
+
+### Factories and builders
+
+```csharp
+public interface IFactory<out T>       { T GetInstance(); }
+
+public interface IBuilder<out T>       { void Build(); T Entity { get; } }
+
+public interface IFluentBuilder<out T> { IFluentBuilder<T> Build(); T Entity { get; } }
+```
+
+### Converters and formatters
+
+```csharp
+public interface IConverter<in TFrom, out TTo> { TTo Convert(TFrom input); }
+
+public interface IFormatter<in T>              { string Format(T input); }
+```
+
+### Validation and equality
+
+```csharp
+public interface IValidatable          { bool IsValid(); }
+public interface IValidatable<in T>    { bool IsValid(T validator); }
+
+public interface IValueEquatable<in T> { bool ValueEquals(T other); }
+```
+
+## Usage example
+
+```csharp
+// Implement in your data layer:
+public class OrderRepository : IRepository<Order>
+{
+    private readonly AppDbContext _db;
+    public OrderRepository(AppDbContext db) => _db = db;
+
+    public int Count() => _db.Orders.Count();
+    public int Count(Expression<Func<Order, bool>> predicate) => _db.Orders.Count(predicate);
+    public Order Get(Expression<Func<Order, bool>> predicate) => _db.Orders.First(predicate);
+    public IEnumerable<Order> GetAll() => _db.Orders.ToList();
+    public IEnumerable<Order> GetAll(Expression<Func<Order, bool>> predicate) => _db.Orders.Where(predicate).ToList();
+    public void Add(Order entity) => _db.Orders.Add(entity);
+    public void AddOrUpdate(Order entity) => _db.Orders.Update(entity);
+    public void AddRange(IEnumerable<Order> entities) => _db.Orders.AddRange(entities);
+    public void Remove(Order entity) => _db.Orders.Remove(entity);
+    public void RemoveRange(IEnumerable<Order> entities) => _db.Orders.RemoveRange(entities);
+    public void RemoveAll(Expression<Func<Order, bool>> predicate) => _db.Orders.RemoveRange(_db.Orders.Where(predicate));
+    public void RemoveAll() => _db.Orders.RemoveRange(_db.Orders);
+    public int SaveChanges() => _db.SaveChanges();
+}
+```
+
+## License
+
+MIT — see [LICENSE](https://github.com/PFalkowski/StandardInterfaces/blob/master/LICENSE). Contributions welcome.

--- a/StandardInterfaces/IBuilder.cs
+++ b/StandardInterfaces/IBuilder.cs
@@ -1,8 +1,12 @@
-﻿namespace StandardInterfaces
+namespace StandardInterfaces
 {
+    /// <summary>Builds an instance of <typeparamref name="T"/> via a two-step Build/Entity pattern.</summary>
     public interface IBuilder<out T>
     {
+        /// <summary>Executes the build process.</summary>
         void Build();
+
+        /// <summary>The built entity; valid after <see cref="Build"/> has been called.</summary>
         T Entity { get; }
     }
 }

--- a/StandardInterfaces/IConverter.cs
+++ b/StandardInterfaces/IConverter.cs
@@ -1,7 +1,9 @@
-﻿namespace StandardInterfaces
+namespace StandardInterfaces
 {
+    /// <summary>Converts a value of type <typeparamref name="TFrom"/> to <typeparamref name="TTo"/>.</summary>
     public interface IConverter<in TFrom, out TTo>
     {
+        /// <summary>Converts <paramref name="input"/> and returns the result.</summary>
         TTo Convert(TFrom input);
     }
 }

--- a/StandardInterfaces/IFactory.cs
+++ b/StandardInterfaces/IFactory.cs
@@ -1,7 +1,9 @@
-﻿namespace StandardInterfaces
+namespace StandardInterfaces
 {
+    /// <summary>Creates instances of <typeparamref name="T"/>.</summary>
     public interface IFactory<out T>
     {
+        /// <summary>Returns a new instance of <typeparamref name="T"/>.</summary>
         T GetInstance();
     }
 }

--- a/StandardInterfaces/IFluentBuilder.cs
+++ b/StandardInterfaces/IFluentBuilder.cs
@@ -1,8 +1,12 @@
-﻿namespace StandardInterfaces
+namespace StandardInterfaces
 {
+    /// <summary>Builds an instance of <typeparamref name="T"/> using a fluent (method-chaining) API.</summary>
     public interface IFluentBuilder<out T>
     {
+        /// <summary>Executes the build step and returns <c>this</c> for chaining.</summary>
         IFluentBuilder<T> Build();
+
+        /// <summary>The built entity; valid after <see cref="Build"/> has been called.</summary>
         T Entity { get; }
     }
 }

--- a/StandardInterfaces/IFormatter.cs
+++ b/StandardInterfaces/IFormatter.cs
@@ -1,7 +1,9 @@
-﻿namespace StandardInterfaces
+namespace StandardInterfaces
 {
+    /// <summary>Formats a value of type <typeparamref name="T"/> as a string.</summary>
     public interface IFormatter<in T>
     {
+        /// <summary>Returns a formatted string representation of <paramref name="input"/>.</summary>
         string Format(T input);
     }
 }

--- a/StandardInterfaces/IReadOnlyRepository.cs
+++ b/StandardInterfaces/IReadOnlyRepository.cs
@@ -1,15 +1,25 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace StandardInterfaces
 {
+    /// <summary>Read-only view of a data store for <typeparamref name="TEntity"/>.</summary>
     public interface IReadOnlyRepository<TEntity> where TEntity : class
     {
+        /// <summary>Returns the total number of entities.</summary>
         int Count();
+
+        /// <summary>Returns the number of entities matching <paramref name="predicate"/>.</summary>
         int Count(Expression<Func<TEntity, bool>> predicate);
+
+        /// <summary>Returns the first entity matching <paramref name="predicate"/>, or throws if none.</summary>
         TEntity Get(Expression<Func<TEntity, bool>> predicate);
+
+        /// <summary>Returns all entities.</summary>
         IEnumerable<TEntity> GetAll();
+
+        /// <summary>Returns all entities matching <paramref name="predicate"/>.</summary>
         IEnumerable<TEntity> GetAll(Expression<Func<TEntity, bool>> predicate);
     }
 }

--- a/StandardInterfaces/IRepository.cs
+++ b/StandardInterfaces/IRepository.cs
@@ -1,18 +1,34 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace StandardInterfaces
 {
+    /// <summary>Read-write repository for <typeparamref name="TEntity"/>.</summary>
     public interface IRepository<TEntity> : IReadOnlyRepository<TEntity> where TEntity : class
     {
+        /// <summary>Adds <paramref name="entity"/> to the store.</summary>
         void Add(TEntity entity);
+
+        /// <summary>Adds <paramref name="entity"/> if absent; updates it otherwise.</summary>
         void AddOrUpdate(TEntity entity);
+
+        /// <summary>Adds all <paramref name="entities"/> to the store.</summary>
         void AddRange(IEnumerable<TEntity> entities);
+
+        /// <summary>Removes <paramref name="entity"/> from the store.</summary>
         void Remove(TEntity entity);
+
+        /// <summary>Removes all <paramref name="entities"/> from the store.</summary>
         void RemoveRange(IEnumerable<TEntity> entities);
+
+        /// <summary>Removes all entities matching <paramref name="predicate"/>.</summary>
         void RemoveAll(Expression<Func<TEntity, bool>> predicate);
+
+        /// <summary>Removes all entities.</summary>
         void RemoveAll();
+
+        /// <summary>Persists pending changes and returns the number of records affected.</summary>
         int SaveChanges();
     }
 }

--- a/StandardInterfaces/IUnitOfWork.cs
+++ b/StandardInterfaces/IUnitOfWork.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
 
 namespace StandardInterfaces
 {
+    /// <summary>Coordinates a transaction across one or more repositories.</summary>
     public interface IUnitOfWork : IDisposable
     {
+        /// <summary>Commits all changes made within this unit of work.</summary>
         void Complete();
     }
 }

--- a/StandardInterfaces/IValidatable.cs
+++ b/StandardInterfaces/IValidatable.cs
@@ -1,11 +1,16 @@
-﻿namespace StandardInterfaces
+namespace StandardInterfaces
 {
+    /// <summary>Supports self-validation.</summary>
     public interface IValidatable
     {
+        /// <summary>Returns <c>true</c> if the instance is in a valid state.</summary>
         bool IsValid();
     }
+
+    /// <summary>Supports validation using an external <typeparamref name="T"/> validator.</summary>
     public interface IValidatable<in T>
     {
+        /// <summary>Returns <c>true</c> if the instance is valid according to <paramref name="validator"/>.</summary>
         bool IsValid(T validator);
     }
 }

--- a/StandardInterfaces/IValueEquatable.cs
+++ b/StandardInterfaces/IValueEquatable.cs
@@ -1,7 +1,9 @@
-﻿namespace StandardInterfaces
+namespace StandardInterfaces
 {
+    /// <summary>Supports value-based equality comparison with another instance of <typeparamref name="T"/>.</summary>
     public interface IValueEquatable<in T>
     {
+        /// <summary>Returns <c>true</c> if this instance is value-equal to <paramref name="other"/>.</summary>
         bool ValueEquals(T other);
     }
 }

--- a/StandardInterfaces/StandardInterfaces.csproj
+++ b/StandardInterfaces/StandardInterfaces.csproj
@@ -2,27 +2,32 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
     <Authors>Piotr Falkowski</Authors>
-    <Company></Company>
-    <Description>Your everyday interfaces: IUnitOfWork, IRepository&lt;T&gt;, IFactory&lt;T&gt;, IValidatable, IValueEquatable&lt;T&gt;, IConverter&lt;TIn,TOut&gt;, IFormatter&lt;T&gt;. Nothing more, nothing less. .NET Standard 2.0, MIT</Description>
-    <Copyright>Piotr Falkowski © 2021</Copyright>
-    <PackageLicenseUrl></PackageLicenseUrl>
+    <Description>Your everyday interfaces: IUnitOfWork, IRepository&lt;T&gt;, IFactory&lt;T&gt;, IValidatable, IValueEquatable&lt;T&gt;, IConverter&lt;TIn,TOut&gt;, IFormatter&lt;T&gt;. Nothing more, nothing less. netstandard2.0, MIT.</Description>
+    <Copyright>Piotr Falkowski © 2026</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/PFalkowski/StandardInterfaces</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PFalkowski/StandardInterfaces</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>IFactory, IValueEquatable, IValidatable, Factory</PackageTags>
-    <PackageReleaseNotes>Add SaveChanges method declaration to IRepository</PackageReleaseNotes>
-    <Version>3.1.0</Version>
+    <PackageTags>IFactory;IValueEquatable;IValidatable;IRepository;IUnitOfWork;interfaces</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Version>3.2.0</Version>
+
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What & why

### Phase 1 — Divergence check
✅ Repo and NuGet both at 3.1.0 — no source reconstruction needed.

### Phase 3 — Modernize (v3.2.0, non-breaking)
- **csproj:** Remove deprecated `PackageLicenseUrl` / `GeneratePackageOnBuild` / hardcoded `PackageReleaseNotes`; update copyright year; SourceLink 1.0.0 → 8.0.0; add `LangVersion latest`, `Nullable enable`, `GenerateDocumentationFile`; add `PackageReadmeFile` (README now packed into the NuGet package)
- **XML docs:** All 10 interfaces and ~25 members now have `<summary>` tags — zero CS1591 warnings; consumers see IntelliSense descriptions
- **BOM markers:** Removed from all source files
- **README:** Rewritten from 5 lines to full docs — badges, every interface shown, usage example

### Phase 6 — CI/CD + SonarCloud
- **ci.yml:** Build on push/PR to master (build-only — no test project)
- **publish.yml:** Tag-driven NuGet publish via **Trusted Publishing (OIDC)** — no long-lived key
- **sonar.yml:** CI-based SonarCloud static analysis without coverage (pure interface library — no logic to cover avoids a 0% coverage gate failure)

## One-time setup required
- [ ] Set repo **variable** `NUGET_USER = PFalkowski` (Settings → Secrets and variables → Actions → Variables)
- [ ] Create NuGet **Trusted Publishing policy** matching `PFalkowski / StandardInterfaces / publish.yml`
- [ ] Turn **Automatic Analysis OFF** in SonarCloud once the project appears (Administration → Analysis Method)

## Ship
After merge: tag `v3.2.0` to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)